### PR TITLE
BUG#418256 Return full response as last error resort

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var transifex = function (config) {
                 if (!err && response.statusCode == 200) {
                     resolve(body);
                 } else {
-                    reject(err || body);
+                    reject(err || body || response);
                 }
             });
         });


### PR DESCRIPTION
Try to log entire error response if no actual error or its body.